### PR TITLE
feat: register dataset classes from summary file

### DIFF
--- a/eegdash/registry.py
+++ b/eegdash/registry.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any, Dict
+
+
+def register_openneuro_datasets(
+    summary_file: str | Path,
+    *,
+    base_class=None,
+    namespace: Dict[str, Any] | None = None,
+) -> Dict[str, type]:
+    """Dynamically create dataset classes from a summary file.
+
+    Parameters
+    ----------
+    summary_file : str | Path
+        Path to a CSV file where each line starts with the dataset identifier.
+    base_class : type | None
+        Base class for the generated datasets. If ``None``, defaults to
+        :class:`eegdash.api.EEGDashDataset`.
+    namespace : dict | None
+        Mapping where the new classes will be registered. Defaults to the
+        module's global namespace.
+
+    Returns
+    -------
+    dict
+        Mapping from class names to the generated classes.
+    """
+    if base_class is None:
+        from .api import EEGDashDataset as base_class  # lazy import
+
+    summary_path = Path(summary_file)
+    namespace = namespace if namespace is not None else globals()
+    registered: Dict[str, type] = {}
+
+    with summary_path.open() as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if not row:
+                continue
+            dataset_id = row[0].strip()
+            if not dataset_id or dataset_id.startswith("#"):
+                continue
+            class_name = dataset_id.upper()
+
+            def __init__(self, cache_dir: str, query: dict | None = None, s3_bucket: str | None = None, **kwargs):
+                q = {"dataset": self._dataset}
+                if query:
+                    q.update(query)
+                super().__init__(query=q, cache_dir=cache_dir, s3_bucket=s3_bucket, **kwargs)
+
+            cls = type(class_name, (base_class,), {"_dataset": dataset_id, "__init__": __init__})
+            namespace[class_name] = cls
+            registered[class_name] = cls
+
+    return registered

--- a/tests/test_dataset_registration.py
+++ b/tests/test_dataset_registration.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import importlib.util
+
+import pytest
+
+
+class DummyBase:
+    pass
+
+
+def test_register_openneuro_datasets(tmp_path: Path):
+    module_path = Path(__file__).resolve().parents[1] / "eegdash" / "registry.py"
+    spec = importlib.util.spec_from_file_location("registry", module_path)
+    registry = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(registry)
+
+    summary = tmp_path / "dataset_summary.csv"
+    summary.write_text(
+        "\n".join(
+            [
+                "ds002718,18,18,1,74,250,14.844",
+                "ds000001,1,1,1,1,1,1",
+            ]
+        )
+    )
+    namespace = {}
+    registered = registry.register_openneuro_datasets(
+        summary, namespace=namespace, base_class=DummyBase
+    )
+
+    assert set(registered) == {"DS002718", "DS000001"}
+    ds_class = registered["DS002718"]
+    assert ds_class is namespace["DS002718"]
+    assert issubclass(ds_class, DummyBase)
+    assert ds_class._dataset == "ds002718"


### PR DESCRIPTION
## Summary
- add `register_openneuro_datasets` for dynamically creating dataset-specific classes from a summary file
- test registration of multiple datasets

## Testing
- `pytest tests/test_dataset_registration.py -q`
- `pre-commit run --files eegdash/registry.py tests/test_dataset_registration.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fad67206c8320815508effb06b069